### PR TITLE
In WordPress deployment, switch MySQL image to MariaDB 10.4

### DIFF
--- a/mysql-deployment.yaml
+++ b/mysql-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.7
+      - image: mariadb:10.4
         name: mysql
         env:
         - name: MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
This image is compatible with MySQL 5.7, and it is built on a more
familiar base image (Ubuntu Focal) than the upstream MySQL image.
