### PR TITLE
Introduce support for Bearer Token Dashboard access

### DIFF
--- a/kubernetes-dashboard-adminuser.yaml
+++ b/kubernetes-dashboard-adminuser.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/kubernetes-dashboard-crb.yaml
+++ b/kubernetes-dashboard-crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard


### PR DESCRIPTION
Since the Kubernetes Dashboard only supports logging in with a Bearer Token, we add two new manifest files for creating a Service Account and a ClusterRoleBinding.

Reference:
https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard